### PR TITLE
Fix instruction cache console bug

### DIFF
--- a/source/LibKuribo/modules/kxer/Loader.cxx
+++ b/source/LibKuribo/modules/kxer/Loader.cxx
@@ -287,9 +287,9 @@ LoadResult Load(const LoadParam& param, LoadedKXE& out) {
   auto* pCacheBlock = reinterpret_cast<u8*>(
       reinterpret_cast<u32>(pCode.get()) & ~0x1F);
   for (u32 i = 0; i < pHeader->code.file_size; i += 32) {
-    dcbst(pCode.get() + i);
+    dcbst(pCacheBlock + i);
     asm("sync");
-    icbi(pCode.get() + i);
+    icbi(pCacheBlock + i);
   }
 #endif
 

--- a/source/LibKuribo/modules/kxer/Loader.cxx
+++ b/source/LibKuribo/modules/kxer/Loader.cxx
@@ -287,7 +287,7 @@ LoadResult Load(const LoadParam& param, LoadedKXE& out) {
   auto *cacheBegin = reinterpret_cast<u8*>(
       reinterpret_cast<u32>(pCode.get()) & ~0x1F);
   auto *cacheEnd = reinterpret_cast<u8*>(
-      (reinterpret_cast<u32>(pCode.get()) + pHeader->code.file_size + 0x20) & ~0x1F);
+      (reinterpret_cast<u32>(pCode.get()) + pHeader->code.file_size + 0x1F) & ~0x1F);
   for (auto* it = cacheBegin; it < cacheEnd; it += 32) {
     dcbst(it);
     asm("sync");

--- a/source/LibKuribo/modules/kxer/Loader.cxx
+++ b/source/LibKuribo/modules/kxer/Loader.cxx
@@ -284,9 +284,10 @@ LoadResult Load(const LoadParam& param, LoadedKXE& out) {
 
 #if KURIBO_PLATFORM_WII
   // Cache blocks are 32 bytes in size
+  u32 adjustment = reinterpret_cast<u32>(pCode.get());
   auto* pCacheBlock = reinterpret_cast<u8*>(
-      reinterpret_cast<u32>(pCode.get()) & ~0x1F);
-  for (u32 i = 0; i < pHeader->code.file_size; i += 32) {
+      reinterpret_cast<u32>(pCode.get()) - adjustment);
+  for (u32 i = 0; i < pHeader->code.file_size + adjustment; i += 32) {
     dcbst(pCacheBlock + i);
     asm("sync");
     icbi(pCacheBlock + i);

--- a/source/LibKuribo/modules/kxer/Loader.cxx
+++ b/source/LibKuribo/modules/kxer/Loader.cxx
@@ -284,7 +284,7 @@ LoadResult Load(const LoadParam& param, LoadedKXE& out) {
 
 #if KURIBO_PLATFORM_WII
   // Cache blocks are 32 bytes in size
-  u32 adjustment = reinterpret_cast<u32>(pCode.get());
+  u32 adjustment = reinterpret_cast<u32>(pCode.get()) % 32;
   auto* pCacheBlock = reinterpret_cast<u8*>(
       reinterpret_cast<u32>(pCode.get()) - adjustment);
   for (u32 i = 0; i < pHeader->code.file_size + adjustment; i += 32) {

--- a/source/LibKuribo/modules/kxer/Loader.cxx
+++ b/source/LibKuribo/modules/kxer/Loader.cxx
@@ -284,7 +284,8 @@ LoadResult Load(const LoadParam& param, LoadedKXE& out) {
 
 #if KURIBO_PLATFORM_WII
   // Cache blocks are 32 bytes in size
-  KURIBO_ASSERT((reinterpret_cast<u32>(pCode.get()) % 32) == 0); 
+  auto* pCacheBlock = reinterpret_cast<u8*>(
+      reinterpret_cast<u32>(pCode.get()) & ~0x1F);
   for (u32 i = 0; i < pHeader->code.file_size; i += 32) {
     dcbst(pCode.get() + i);
     asm("sync");

--- a/source/LibKuribo/modules/kxer/Loader.cxx
+++ b/source/LibKuribo/modules/kxer/Loader.cxx
@@ -284,7 +284,8 @@ LoadResult Load(const LoadParam& param, LoadedKXE& out) {
 
 #if KURIBO_PLATFORM_WII
   // Cache blocks are 32 bytes in size
-  for (int i = 0; i < pHeader->code.file_size; i += 32) {
+  KURIBO_ASSERT((reinterpret_cast<u32>(pCode.get()) % 32) == 0); 
+  for (u32 i = 0; i < pHeader->code.file_size; i += 32) {
     dcbst(pCode.get() + i);
     asm("sync");
     icbi(pCode.get() + i);

--- a/source/LibKuribo/modules/kxer/Loader.cxx
+++ b/source/LibKuribo/modules/kxer/Loader.cxx
@@ -284,13 +284,14 @@ LoadResult Load(const LoadParam& param, LoadedKXE& out) {
 
 #if KURIBO_PLATFORM_WII
   // Cache blocks are 32 bytes in size
-  u32 adjustment = reinterpret_cast<u32>(pCode.get()) % 32;
-  auto* pCacheBlock = reinterpret_cast<u8*>(
-      reinterpret_cast<u32>(pCode.get()) - adjustment);
-  for (u32 i = 0; i < pHeader->code.file_size + adjustment; i += 32) {
-    dcbst(pCacheBlock + i);
+  auto *cacheBegin = reinterpret_cast<u8*>(
+      reinterpret_cast<u32>(pCode.get()) & ~0x1F);
+  auto *cacheEnd = reinterpret_cast<u8*>(
+      (reinterpret_cast<u32>(pCode.get()) + pHeader->code.file_size + 0x20) & ~0x1F);
+  for (auto* it = cacheBegin; it < cacheEnd; it += 32) {
+    dcbst(it);
     asm("sync");
-    icbi(pCacheBlock + i);
+    icbi(it);
   }
 #endif
 


### PR DESCRIPTION
This fixes spurious crashes on console when loading modules. Before the only instructions that were properly re-cached were ones that got patched with relocation data. As it turns out this simply wasn't enough to make hardware happy.